### PR TITLE
fix: handle array and non-string values in fill_form input data

### DIFF
--- a/docs/source/commands/fill_form.rst
+++ b/docs/source/commands/fill_form.rst
@@ -72,3 +72,30 @@ Input data
       "checkbox_1": "On",
       "radio_2": 2,
     }
+
+Field values may also be given as a list of entries, which is handy when the data comes
+from a serialized html form or from the :ref:`commands_dump_data_fields` command:
+
+.. code-block:: JSON
+
+    [
+      {"name": "field_1", "value": "text value"},
+      {"name": "checkbox_1", "value": "On"}
+    ]
+
+The ``FieldName``/``FieldValue`` keys, as dumped by the
+:ref:`commands_dump_data_fields` command, are accepted as well, so that a dumped
+form can be edited and fed back:
+
+.. code-block:: JSON
+
+    [
+      {"FieldName": "field_1", "FieldValue": "text value"},
+      {"FieldName": "checkbox_1", "FieldValue": "On"}
+    ]
+
+An entry with a name but no value clears the related field.
+
+Whatever the layout, a field value may be a string, a number, a boolean or ``null``.
+Booleans are mapped to the ``On``/``Off`` pdf states, so that checkboxes can be driven
+with ``true``/``false``, while ``null`` clears the field.

--- a/pdffiller/cli/commands/fill_form.py
+++ b/pdffiller/cli/commands/fill_form.py
@@ -1,4 +1,3 @@
-import html
 import json
 import os
 import sys
@@ -18,6 +17,7 @@ from pdffiller.exceptions import (
 from pdffiller.io.output import PdfFillerOutput
 from pdffiller.pdf import Pdf
 from pdffiller.typing import Any, Dict
+from pdffiller.utils import normalize_field_data
 
 from ..exit_codes import ERROR_ENCOUNTERED
 
@@ -94,10 +94,10 @@ def fill_form(parser: PdfFillerArgumentParser, *args: Any) -> Any:
     if not opts.data and not opts.input_data:
         raise CommandLineError("no data file path given")
 
-    input_data: Dict[str, str] = {}
+    raw_data: Any = None
     if opts.input_data:
         try:
-            input_data = json.loads(opts.input_data)
+            raw_data = json.loads(opts.input_data)
         except Exception as exg:  # pylint: disable=broad-except
             output.error("Failed to load json input data")
             raise AbortExecution(ERROR_ENCOUNTERED) from exg
@@ -111,25 +111,28 @@ def fill_form(parser: PdfFillerArgumentParser, *args: Any) -> Any:
             with open(opts.data, "r", encoding="utf-8") as stream:
                 try:
                     if os.path.splitext(opts.data)[1] in [".yaml", ".yml"]:
-                        input_data = yaml.safe_load(stream)
+                        raw_data = yaml.safe_load(stream)
                     else:
-                        input_data = json.load(stream)
+                        raw_data = json.load(stream)
                 except Exception as exg:  # pylint: disable=broad-except
                     output.error(f"Failed to load {opts.data} input data file")
                     raise AbortExecution(ERROR_ENCOUNTERED) from exg
         elif not os.isatty(sys.stdin.fileno()):
             try:
-                input_data = json.load(sys.stdin)
+                raw_data = json.load(sys.stdin)
             except Exception as exg:  # pylint: disable=broad-except
                 output.error(f"Failed to load {opts.data} input data file : " + str(exg))
                 raise AbortExecution(ERROR_ENCOUNTERED) from exg
 
-    if isinstance(input_data, list) and isinstance(input_data[0], dict):
-        input_dict = {}
-        for field in input_data:
-            if "name" in field and "value" in field:
-                input_dict[html.unescape(field["name"])] = html.unescape(field["value"])
-        input_data = input_dict
+    input_data: Dict[str, str] = {}
+    try:
+        input_data.update(normalize_field_data(raw_data))
+    except PdfFillerException as exp:
+        output.error(str(exp))
+        raise AbortExecution(ERROR_ENCOUNTERED) from exp
+
+    if not input_data:
+        output.warning("input data holds no field value to fill in")
 
     output.info(f"input file: {opts.file}")
     output.info("input values are:")

--- a/pdffiller/pdf.py
+++ b/pdffiller/pdf.py
@@ -18,6 +18,7 @@ from pdffiller.exceptions import PdfFillerException
 from pdffiller.io.output import PdfFillerOutput
 
 from .typing import Any, cast, Dict, List, Optional, PathLike, StreamType, Type
+from .utils import to_field_value
 from .widgets.base import Widget
 from .widgets.checkbox import CheckBoxWidget
 from .widgets.radio import RadioWidget
@@ -327,7 +328,7 @@ class Pdf:
         self,
         input_file: PathLike,
         output_file: PathLike,
-        data: Dict[str, str],
+        data: Dict[str, Any],
         flatten: bool = True,
     ) -> "Pdf":
         """
@@ -336,9 +337,10 @@ class Pdf:
         Args:
             input_file (PathLike): The input file path.
             output_file (PathLike): The output file path.
-            data (Dict[str, Union[str, bool, int]]): A dictionary where keys are form field names
-                and values are the data to fill the fields with.  Values can be strings, booleans,
-                or integers.
+            data (Dict[str, Union[str, bool, int, None]]): A dictionary where keys are form field
+                names and values are the data to fill the fields with. Values can be strings,
+                numbers, booleans (mapped to the ``On``/``Off`` states) or None (clears the
+                field).
             flatten (bool): Whether to flatten the form after filling, making the fields read-only
                 (default: False).
 
@@ -365,7 +367,7 @@ class Pdf:
         for page in document:
             for field in page.widgets():
                 if field.field_name in data:
-                    value = data[field.field_name]
+                    value = to_field_value(data[field.field_name], field.field_name)
 
                     # Handling checkboxes
                     if (

--- a/pdffiller/utils.py
+++ b/pdffiller/utils.py
@@ -1,7 +1,17 @@
+import html
 import os
 from pathlib import Path
 
-from pdffiller.typing import Any, Optional, PathLike
+from pdffiller.exceptions import PdfFillerException
+from pdffiller.typing import Any, Dict, Optional, PathLike, Sequence
+
+#: Accepted key names holding the field name in a list based input data
+FIELD_NAME_KEYS = ("name", "FieldName", "field_name")
+
+#: Accepted key names holding the field value in a list based input data
+FIELD_VALUE_KEYS = ("value", "FieldValue", "field_value")
+
+_MISSING = object()
 
 
 def str_to_path(path: Optional[PathLike]) -> Any:
@@ -34,3 +44,104 @@ def path_to_str(path: Optional[PathLike]) -> Any:
         return None
 
     return os.fspath(path)
+
+
+def _lookup(entry: Dict[Any, Any], keys: Sequence[str]) -> Any:
+    """Return the value of the first key of ``keys`` found in ``entry``
+
+    :param entry: The mapping to look into
+    :param keys: The candidate key names, by order of precedence
+    :return: The value found, else the ``_MISSING`` sentinel
+    """
+    for key in keys:
+        if key in entry:
+            return entry[key]
+
+    return _MISSING
+
+
+def to_field_value(value: Any, name: Optional[str] = None) -> str:
+    """Convert a value coming from a json/yaml input data into a pdf field value
+
+    ``None`` is converted to an empty string, thus clearing the field, and booleans
+    are converted to the ``On``/``Off`` pdf states so that checkboxes can be driven
+    with ``true``/``false``.
+
+    :param value: The value to be converted
+    :param name: The field name the value belongs to, used for error reporting only
+    :return: The value as a string
+    :raises PdfFillerException: when the value cannot be used as a field value
+    """
+    if value is None:
+        return ""
+
+    if isinstance(value, bool):
+        return "On" if value else "Off"
+
+    if isinstance(value, str):
+        return value
+
+    if isinstance(value, (int, float)):
+        return str(value)
+
+    location = f" for field '{name}'" if name else ""
+    raise PdfFillerException(
+        f"unsupported {type(value).__name__} value{location}: "
+        "expecting a string, a number, a boolean or null"
+    )
+
+
+def normalize_field_data(data: Any) -> Dict[str, str]:
+    """Normalize input data into a field name to field value mapping
+
+    Both supported input data layouts are accepted:
+
+    * a mapping, i.e. ``{"Lastname": "Doe"}``
+    * a list of entries, i.e. ``[{"name": "Lastname", "value": "Doe"}]``, where the
+      keys may also be spelled ``FieldName``/``FieldValue`` as dumped by the
+      ``dump_data_fields`` command. Names and values of such entries are html
+      unescaped, as they usually come from a serialized html form. An entry without
+      any value key clears the field.
+
+    :param data: The raw data as loaded from the json/yaml input
+    :return: The field name to field value mapping
+    :raises PdfFillerException: when the input data layout is not supported
+    """
+    if data is None:
+        return {}
+
+    if isinstance(data, dict):
+        return {str(name): to_field_value(value, str(name)) for name, value in data.items()}
+
+    if isinstance(data, list):
+        fields: Dict[str, str] = {}
+        for index, entry in enumerate(data):
+            if not isinstance(entry, dict):
+                raise PdfFillerException(
+                    f"invalid input data: entry #{index + 1} is a {type(entry).__name__} "
+                    "while expecting an object holding a "
+                    f"{' or '.join(repr(key) for key in FIELD_NAME_KEYS)} key"
+                )
+
+            name = _lookup(entry, FIELD_NAME_KEYS)
+            if name is _MISSING:
+                raise PdfFillerException(
+                    f"invalid input data: entry #{index + 1} has no "
+                    f"{' or '.join(repr(key) for key in FIELD_NAME_KEYS)} key"
+                )
+
+            value = _lookup(entry, FIELD_VALUE_KEYS)
+            name = html.unescape(str(name))
+            if isinstance(value, str):
+                value = html.unescape(value)
+            elif value is _MISSING:
+                value = None
+
+            fields[name] = to_field_value(value, name)
+
+        return fields
+
+    raise PdfFillerException(
+        f"invalid input data: expecting an object or a list of objects, "
+        f"got a {type(data).__name__}"
+    )

--- a/tests/cli/test_fill_form.py
+++ b/tests/cli/test_fill_form.py
@@ -6,9 +6,11 @@ import pytest
 from pdffiller.cli import cli
 from pdffiller.cli.exit_codes import (
     ERROR_COMMAND_NAME,
+    ERROR_ENCOUNTERED,
     ERROR_UNEXPECTED,
     SUCCESS,
 )
+from pdffiller.pdf import Pdf
 
 
 def test_incomplete_no_action():
@@ -101,3 +103,120 @@ def test_complete_with_file_and_string(test_data_dir, input_json_fields, output_
     # Test with direct call to main function
     assert cli.main(["fill_form"] + argv) == SUCCESS
     assert output_pdf_path.exists()
+
+
+@pytest.mark.parametrize(
+    "input_data",
+    [
+        '[{"name": "Lastname", "value": "Doe"}, {"name": "Men", "value": "On"}]',
+        '[{"FieldName": "Lastname", "FieldValue": "Doe"}, {"FieldName": "Men"}]',
+        '[{"name": "Lastname", "value": 42}, {"name": "Men", "value": true}]',
+        '[{"name": "Lastname", "value": null}]',
+        "[]",
+        '{"Lastname": "Doe", "Men": true}',
+    ],
+)
+def test_complete_with_list_input_data(test_data_dir, output_pdf_path, input_data):
+    """test the supported input data layouts given on the command-line"""
+
+    argv = [
+        "-i",
+        input_data,
+        "-o",
+        str(output_pdf_path),
+        str(test_data_dir / "input.pdf"),
+    ]
+
+    assert cli.main(["fill_form"] + argv) == SUCCESS
+    assert output_pdf_path.exists()
+
+
+@pytest.mark.parametrize(
+    "input_data",
+    [
+        '["Lastname"]',
+        "42",
+        '[{"Readonly": true}]',
+        '{"Lastname": ["Doe"]}',
+    ],
+)
+def test_complete_with_invalid_input_data(test_data_dir, output_pdf_path, input_data):
+    """test that an unsupported input data layout is reported without traceback"""
+
+    argv = [
+        "-i",
+        input_data,
+        "-o",
+        str(output_pdf_path),
+        str(test_data_dir / "input.pdf"),
+    ]
+
+    assert cli.main(["fill_form"] + argv) == ERROR_ENCOUNTERED
+    assert not output_pdf_path.exists()
+
+
+@pytest.mark.parametrize("extension", [".json", ".yaml", ".yml"])
+@pytest.mark.parametrize("content", ["[]", "{}"])
+def test_complete_with_empty_data_file(
+    test_data_dir, output_pdf_path, tmp_path, capsys, extension, content
+):
+    """test a data file holding an empty array/mapping, thus no field to fill in"""
+
+    data_path = tmp_path / f"empty{extension}"
+    data_path.write_text(content, encoding="utf-8")
+
+    argv = [
+        "-d",
+        str(data_path),
+        "-o",
+        str(output_pdf_path),
+        str(test_data_dir / "input.pdf"),
+    ]
+
+    assert cli.main(["fill_form"] + argv) == SUCCESS
+    assert "no field value to fill in" in capsys.readouterr().err
+
+    # The input pdf is copied as is, keeping all its form fields untouched
+    assert output_pdf_path.exists()
+    assert Pdf(str(output_pdf_path)).schema == Pdf(str(test_data_dir / "input.pdf")).schema
+
+
+@pytest.mark.parametrize("extension", [".yaml", ".yml"])
+def test_complete_with_void_yaml_data_file(
+    test_data_dir, output_pdf_path, tmp_path, capsys, extension
+):
+    """test a void yaml data file, which yaml loads as no data at all"""
+
+    data_path = tmp_path / f"void{extension}"
+    data_path.write_text("", encoding="utf-8")
+
+    argv = [
+        "-d",
+        str(data_path),
+        "-o",
+        str(output_pdf_path),
+        str(test_data_dir / "input.pdf"),
+    ]
+
+    assert cli.main(["fill_form"] + argv) == SUCCESS
+    assert "no field value to fill in" in capsys.readouterr().err
+    assert output_pdf_path.exists()
+
+
+def test_complete_with_void_json_data_file(test_data_dir, output_pdf_path, tmp_path, capsys):
+    """test a void json data file, which is not a valid json document"""
+
+    data_path = tmp_path / "void.json"
+    data_path.write_text("", encoding="utf-8")
+
+    argv = [
+        "-d",
+        str(data_path),
+        "-o",
+        str(output_pdf_path),
+        str(test_data_dir / "input.pdf"),
+    ]
+
+    assert cli.main(["fill_form"] + argv) == ERROR_ENCOUNTERED
+    assert f"Failed to load {data_path} input data file" in capsys.readouterr().err
+    assert not output_pdf_path.exists()

--- a/tests/unit/test_normalize_field_data.py
+++ b/tests/unit/test_normalize_field_data.py
@@ -1,0 +1,78 @@
+import pytest
+
+from pdffiller.exceptions import PdfFillerException
+from pdffiller.utils import normalize_field_data, to_field_value
+
+
+def test_mapping_input():
+    assert normalize_field_data({"Lastname": "Doe"}) == {"Lastname": "Doe"}
+
+
+def test_no_input():
+    assert normalize_field_data(None) == {}
+
+
+def test_list_input():
+    data = [
+        {"name": "Lastname", "value": "Doe"},
+        {"name": "Firstname", "value": "John"},
+    ]
+    assert normalize_field_data(data) == {"Lastname": "Doe", "Firstname": "John"}
+
+
+def test_empty_list_input():
+    """an empty list is a valid input holding no field to fill in"""
+    assert normalize_field_data([]) == {}
+
+
+def test_list_input_with_dumped_keys():
+    """the keys dumped by the dump_data_fields command are accepted as well"""
+    data = [
+        {"FieldName": "Lastname", "FieldValue": "Doe"},
+        {"field_name": "Firstname", "field_value": "John"},
+    ]
+    assert normalize_field_data(data) == {"Lastname": "Doe", "Firstname": "John"}
+
+
+def test_list_input_without_value():
+    """an entry without any value key clears the field"""
+    assert normalize_field_data([{"FieldName": "Lastname"}]) == {"Lastname": ""}
+
+
+def test_list_input_is_unescaped():
+    data = [{"name": "Last&amp;name", "value": "Doe &gt; Do"}]
+    assert normalize_field_data(data) == {"Last&name": "Doe > Do"}
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        ("Doe", "Doe"),
+        (None, ""),
+        (True, "On"),
+        (False, "Off"),
+        (42, "42"),
+        (4.5, "4.5"),
+    ],
+)
+def test_value_conversion(value, expected):
+    assert to_field_value(value) == expected
+    assert normalize_field_data({"Lastname": value}) == {"Lastname": expected}
+    assert normalize_field_data([{"name": "Lastname", "value": value}]) == {"Lastname": expected}
+
+
+@pytest.mark.parametrize("data", [42, "Doe", ["Lastname"], [42], [["Lastname", "Doe"]]])
+def test_invalid_input_layout(data):
+    with pytest.raises(PdfFillerException):
+        normalize_field_data(data)
+
+
+def test_list_input_without_name():
+    with pytest.raises(PdfFillerException):
+        normalize_field_data([{"Readonly": True}])
+
+
+@pytest.mark.parametrize("value", [["Doe"], {"last": "Doe"}])
+def test_unsupported_value(value):
+    with pytest.raises(PdfFillerException):
+        normalize_field_data({"Lastname": value})


### PR DESCRIPTION
Normalize the json/yaml input data through a single validation boundary, so that an empty array, non-string values and the FieldName/FieldValue keys dumped by dump_data_fields no longer raise a traceback.

Fixes #21